### PR TITLE
change github link to explicit url

### DIFF
--- a/paper.bib
+++ b/paper.bib
@@ -49,7 +49,7 @@ month={May},}
 
 @misc{Norbert,
   author       = {Antoine Liutkus and
-                  Fabian-Robert Stöter},
+                  Fabian-Robert St{\"o}ter},
   title        = {sigsep/norbert: First official Norbert release},
   month        = jul,
   year         = 2019,
@@ -58,7 +58,7 @@ month={May},}
 }
 
 @ARTICLE{separation_metrics,
-author={Emmanuel {Vincent} and Rémi {Gribonval} and Cédric {Fevotte}},
+author={Emmanuel {Vincent} and Remi {Gribonval} and Cedric {Fevotte}},
 journal={IEEE Transactions on Audio, Speech, and Language Processing},
 title={Performance measurement in blind audio source separation},
 year={2006},
@@ -132,14 +132,4 @@ archivePrefix = {arXiv},
   year=2019,
   doi = {10.21105/joss.01667},
   url = {https://doi.org/10.21105/joss.01667}
-}
-
-
-@misc{spleeter,
-  author = {​R. Hennequin and A. Khlif and F. Voituret and M. Moussallam},
-  title = {Spleeter},
-  year = {2020},
-  publisher = {​GitHub},
-  journal = {​GitHub repository},
-  url = {​https://github.com/deezer/spleeter}
 }

--- a/paper.md
+++ b/paper.md
@@ -71,7 +71,7 @@ We present results for soft masking and for multi-channel Wiener filtering (appl
 |Open-Unmix    |6.32|13.33|6.52|11.93|5.23|**10.93**|**6.34**|9.23|5.73|11.12|6.02|10.51|4.02|6.59|4.74|9.31|
 
 
-Spleeter is available on github [@spleeter] with a MIT license. This repository will be possibly used for releasing other models with improved performances or models separating into more than $5$ stems in the future.
+Spleeter is available at <https://www.github.com/deezer/spleeter> with a MIT license. This repository will be possibly used for releasing other models with improved performances or models separating into more than $5$ stems in the future.
 
 
 


### PR DESCRIPTION
avoids infinite loop of the hyperref package mishandling the url link